### PR TITLE
Implement range keyer for number interval matching

### DIFF
--- a/src/helpers/evaluate-keyer.ts
+++ b/src/helpers/evaluate-keyer.ts
@@ -1,5 +1,5 @@
 import { dequal } from 'dequal'
-import { exclude, include } from '../keyers'
+import { exclude, include, range } from '../keyers'
 import { object } from '../keyers/object'
 import { regex } from '../keyers/regex'
 
@@ -19,6 +19,13 @@ export function evaluateKeyer(parsed: any, value: any) {
   if (parsed.keyer === regex.name && typeof value === 'string') {
     const pattern = new RegExp(parsed.pattern, parsed.flags)
     return pattern.test(value)
+  }
+
+  if (parsed.keyer === range.name && typeof value === 'number') {
+    const minMatch = parsed.minInclusive ? value >= parsed.min : value > parsed.min
+    const maxMatch = parsed.maxInclusive ? value <= parsed.max : value < parsed.max
+
+    return minMatch && maxMatch
   }
 
   return false

--- a/src/keyers/index.ts
+++ b/src/keyers/index.ts
@@ -1,3 +1,4 @@
 export * from './exclude'
 export * from './include'
+export * from './range'
 export * from './regex'

--- a/src/keyers/range.ts
+++ b/src/keyers/range.ts
@@ -3,12 +3,12 @@ export interface RangeOptions {
   maxInclusive?: boolean
 }
 
-export function range(min: number, max: number, options: RangeOptions = { minInclusive: true, maxInclusive: true }) {
+export function range(min: number, max: number, { minInclusive = true, maxInclusive = true }: RangeOptions = {}) {
   return JSON.stringify({
     keyer: range.name,
     min,
     max,
-    minInclusive: options.minInclusive ?? true,
-    maxInclusive: options.maxInclusive ?? true,
+    minInclusive,
+    maxInclusive,
   })
 }

--- a/src/keyers/range.ts
+++ b/src/keyers/range.ts
@@ -1,4 +1,4 @@
-export type RangeOptions = {
+export interface RangeOptions {
   minInclusive?: boolean
   maxInclusive?: boolean
 }

--- a/src/keyers/range.ts
+++ b/src/keyers/range.ts
@@ -1,0 +1,14 @@
+export type RangeOptions = {
+  minInclusive?: boolean
+  maxInclusive?: boolean
+}
+
+export function range(min: number, max: number, options: RangeOptions = { minInclusive: true, maxInclusive: true }) {
+  return JSON.stringify({
+    keyer: range.name,
+    min,
+    max,
+    minInclusive: options.minInclusive ?? true,
+    maxInclusive: options.maxInclusive ?? true,
+  })
+}

--- a/src/match.spec.ts
+++ b/src/match.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { exclude, include, regex } from './keyers'
+import { exclude, include, range, regex } from './keyers'
 import { object } from './keyers/object'
 import { match } from './match'
 import { otherwise } from './symbols'
@@ -87,6 +87,72 @@ describe(match.name, () => {
 
       const result = match(testObject)({
         [object({ a: 1, b: { c: 2 } })]: () => 'matched object',
+        [otherwise]: () => 'other',
+      })
+
+      expect(result).toBe('other')
+    })
+  })
+
+  describe('range', () => {
+    it('should match when value is within inclusive range', () => {
+      const result = match(5)({
+        [range(1, 10)]: () => 'between 1 and 10',
+        [otherwise]: () => 'other',
+      })
+
+      expect(result).toBe('between 1 and 10')
+    })
+
+    it('should match when value is at the boundary of inclusive range', () => {
+      const resultMin = match(1)({
+        [range(1, 10)]: () => 'matched',
+        [otherwise]: () => 'other',
+      })
+      const resultMax = match(10)({
+        [range(1, 10)]: () => 'matched',
+        [otherwise]: () => 'other',
+      })
+
+      expect(resultMin).toBe('matched')
+      expect(resultMax).toBe('matched')
+    })
+
+    it('should not match when value is at the boundary of exclusive range', () => {
+      const resultMin = match(1)({
+        [range(1, 10, { minInclusive: false })]: () => 'matched',
+        [otherwise]: () => 'other',
+      })
+      const resultMax = match(10)({
+        [range(1, 10, { maxInclusive: false })]: () => 'matched',
+        [otherwise]: () => 'other',
+      })
+
+      expect(resultMin).toBe('other')
+      expect(resultMax).toBe('other')
+    })
+
+    it('should match when value is within exclusive range', () => {
+      const result = match(5)({
+        [range(1, 10, { minInclusive: false, maxInclusive: false })]: () => 'between 1 and 10',
+        [otherwise]: () => 'other',
+      })
+
+      expect(result).toBe('between 1 and 10')
+    })
+
+    it('should not match when value is outside range', () => {
+      const result = match(11)({
+        [range(1, 10)]: () => 'between 1 and 10',
+        [otherwise]: () => 'other',
+      })
+
+      expect(result).toBe('other')
+    })
+
+    it('should not throw and return otherwise if value is not a number', () => {
+      const result = match('5')({
+        [range(1, 10)]: () => 'matched',
         [otherwise]: () => 'other',
       })
 


### PR DESCRIPTION
Implemented the `range` keyer to allow matching numeric values within a specified interval. The keyer supports specifying whether the minimum and maximum boundaries are inclusive or exclusive.

Example usage:
```ts
match(5)({
  [range(1, 10)]: () => 'between 1 and 10 (inclusive)',
  [range(1, 10, { minInclusive: false, maxInclusive: false })]: () => 'between 1 and 10 (exclusive)',
  [otherwise]: () => 'other'
})
```

---
*PR created automatically by Jules for task [8604506755331895729](https://jules.google.com/task/8604506755331895729) started by @gabrielrufino*